### PR TITLE
dark: fix decimal point cart drawer total amount

### DIFF
--- a/assets/add-to-cart.js
+++ b/assets/add-to-cart.js
@@ -210,7 +210,7 @@ async function updateCartDrawer() {
         <div class="price-wrapper">
           <span class="total-price">${CART_DRAWER_TRANSLATION.totalAmount}</span>
           <div class="currency-wrapper">
-            <span class="currency-value">${cartData.sub_total}</span>
+            <span class="currency-value">${cartData.sub_total.toFixed(2)}</span>
             <span class="currency-code">${currencyCode}</span>
           </div>
           <span class="spinner footer-spinner" style="display: none;"></span>


### PR DESCRIPTION
## JIRA Ticket

[YSHOP2-867](https://youcanshop.atlassian.net/browse/YSHOP2-867?focusedCommentId=20263)

## QA Steps

-  [ ] From the Store Admin area, insure you add a product with a decimal price tag (i.e 14.99)
-  [ ] From the Store Front, add two products to the shopping cart, one of which includes a decimal price tag
-  [ ] Open the shopping cart drawer by clicking on the cart icon from the nav menu
-  [ ] The total amount's decimal point should be fixed to _two digits_

## Note

Leave empty when you have nothing to say


[YSHOP2-867]: https://youcanshop.atlassian.net/browse/YSHOP2-867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ