### PR TITLE
DARK: fix subcategories not displayed

### DIFF
--- a/sections/main-collection.liquid
+++ b/sections/main-collection.liquid
@@ -4,7 +4,7 @@
 {%- assign per_page = section.settings.items_per_page -%}
 <div class='yc-product-listing-container'>
   {%- paginate collection.products by per_page cod, category_id: category.id %}
-    {% if items %}
+    {% if items or subCategories.size > 0 %}
       <div class="collection-heading">
         <div class="breadcrumbs-wrapper">
         {%- render 'breadcrumbs' -%}


### PR DESCRIPTION
## Note

Fix the issue of the subcategories not displayed when the parent category has no products
