### PR TITLE
DARK: the product image on express checkout are not displayed

### DIFF
--- a/sections/product.liquid
+++ b/sections/product.liquid
@@ -455,8 +455,7 @@
      * Well technically, if the seller didn't choos a default variant, we shouldn't select one.
      * The customer should be prompted to select one, if not, they get a warning message.
      */
-    const defaultVariant = variants.find(variant => variant.is_default) || variants[0];
-
+    const defaultVariant = variants.find(variant => variant.is_default);
     const globalProductStr = `{{ selected_product | json }}`;
     const globalProduct = JSON.parse(globalProductStr.slice(1, -1));
 

--- a/snippets/product-card.liquid
+++ b/snippets/product-card.liquid
@@ -4,7 +4,7 @@
   <div class="product-container">
     <img
       class="main-image"
-      src="{{ 'default_product.jpeg' | asset_url }}"
+      src="{% if product.images.size > 0 %}{{ product.images.first }}{% else %}{{ 'default_product.jpeg' | asset_url }}{% endif %}"
       alt="product image"
     >
     <div class="details">


### PR DESCRIPTION
### [Thread Link](https://youcan-shop.slack.com/archives/C04BDG9HEB1/p1703838372306269)

## QA Steps

-  [ ]  Go to seller-area and choose a product also check the Variants are disabled
-  [ ]  Then go to the product page and check on the express checkout; you should see that image.
